### PR TITLE
Update to stable syn, quote and proc-macro2 releases (1.0.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ members = [
   "codegen/",
   "examples/uri_display",
   "examples/from_form_value",
-  "examples/responder",
+#  "examples/responder",
   "examples/generics",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ members = [
   "codegen/",
   "examples/uri_display",
   "examples/from_form_value",
-#  "examples/responder",
+  "examples/responder",
   "examples/generics",
 ]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/SergioBenitez/Devise"
 proc-macro = true
 
 [dependencies]
-quote-next = "1.0.0-rc1"
+quote = "1.0"
 devise_core = { version = "0.2.0", path = "../core/" }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/SergioBenitez/Devise"
 proc-macro = true
 
 [dependencies]
-quote = "0.6"
+quote-next = "1.0.0-rc1"
 devise_core = { version = "0.2.0", path = "../core/" }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,11 +1,13 @@
 #![feature(proc_macro_diagnostic, proc_macro_span)]
 #![recursion_limit="256"]
 
+extern crate devise_core;
 extern crate proc_macro;
 #[macro_use] extern crate quote;
-extern crate devise_core;
 
 use proc_macro::TokenStream;
+use proc_macro::TokenTree::Ident;
+
 use devise_core::*;
 
 struct Naked(bool);
@@ -18,8 +20,8 @@ impl FromMeta for Naked {
             }
 
             let item = list.iter().next().unwrap();
-            if let MetaItem::Ident(ident) = item {
-                if ident == "naked" {
+            if let MetaItem::Path(path) = item {
+                if path.is_ident("naked") {
                     return Ok(Naked(true));
                 }
             }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/SergioBenitez/Devise"
 
 [dependencies]
-quote-next = "1.0.0-rc1"
-proc-macro2-next = { version = "1.0.0-rc1", features = ["nightly"] }
-syn-next = { version = "1.0.0-rc2", features = ["full", "extra-traits"] }
+quote = "1.0"
+proc-macro2 = { version = "1.0", features = ["nightly"] }
+syn = { version = "1.0", features = ["full", "extra-traits"] }
 bitflags = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/SergioBenitez/Devise"
 
 [dependencies]
-quote = "0.6"
-proc-macro2 = { version = "0.4", features = ["nightly"] }
-syn = { version = "0.15", features = ["full", "extra-traits"] }
+quote-next = "1.0.0-rc1"
+proc-macro2-next = { version = "1.0.0-rc1", features = ["nightly"] }
+syn-next = { version = "1.0.0-rc2", features = ["full", "extra-traits"] }
 bitflags = "1.0"

--- a/core/src/ext.rs
+++ b/core/src/ext.rs
@@ -52,7 +52,7 @@ impl PathExt for Path {
 
     fn generics(&self) -> Option<&Punctuated<GenericArgument, Comma>> {
         self.segments.last().and_then(|last| {
-            match last.value().arguments {
+            match last.arguments {
                 PathArguments::AngleBracketed(ref args) => Some(&args.args),
                 _ => None
             }
@@ -133,6 +133,7 @@ fn strip(ty: &mut Type) {
         Type::ImplTrait(ref mut inner) => strip_bounds(&mut inner.bounds),
         Type::TraitObject(ref mut inner) => strip_bounds(&mut inner.bounds),
         Type::Infer(_) | Type::Macro(_) | Type::Verbatim(_) | Type::Never(_) => {  }
+        _ => {}
     }
 }
 

--- a/core/src/from_meta/meta_item.rs
+++ b/core/src/from_meta/meta_item.rs
@@ -6,15 +6,15 @@ use proc_macro::Span;
 
 #[derive(Debug, Copy, Clone)]
 pub enum MetaItem<'a> {
-    Ident(&'a syn::Ident),
+    Path(&'a syn::Path),
     Literal(&'a syn::Lit),
-    KeyValue(&'a syn::Ident, &'a syn::Lit),
+    KeyValue(&'a syn::Path, &'a syn::Lit),
     List(MetaItemList<'a>)
 }
 
 #[derive(Debug, Copy, Clone)]
 pub struct MetaItemList<'a> {
-    pub ident: &'a syn::Ident,
+    pub path: &'a syn::Path,
     pub iter: &'a Punctuated<syn::NestedMeta, syn::token::Comma>
 }
 
@@ -33,10 +33,10 @@ impl<'a> Spanned for MetaItemList<'a> {
 impl<'a> From<&'a syn::Meta> for MetaItem<'a> {
     fn from(meta: &syn::Meta) -> MetaItem {
         match meta {
-            syn::Meta::Word(i) => MetaItem::Ident(i),
-            syn::Meta::NameValue(nv) => MetaItem::KeyValue(&nv.ident, &nv.lit),
+            syn::Meta::Path(path) => MetaItem::Path(path),
+            syn::Meta::NameValue(nv) => MetaItem::KeyValue(&nv.path, &nv.lit),
             syn::Meta::List(list) => {
-                MetaItem::List(MetaItemList { ident: &list.ident, iter: &list.nested })
+                MetaItem::List(MetaItemList { path: &list.path, iter: &list.nested })
             }
         }
     }
@@ -52,12 +52,21 @@ impl<'a> From<&'a syn::NestedMeta> for MetaItem<'a> {
 }
 
 impl<'a> MetaItem<'a> {
-    pub fn name(&self) -> Option<&syn::Ident> {
+    pub fn name(&self) -> Option<String> {
         use MetaItem::*;
 
         match self {
-            Ident(i) | KeyValue(i, _) | List(MetaItemList { ident: i, .. }) => {
-                Some(i)
+            Path(path) | KeyValue(path, _) | List(MetaItemList { path, .. }) => {
+                let mut name = String::new();
+
+                if let Some(_colon2) = path.leading_colon {
+                    name.push_str("::");
+                }
+                for segment in &path.segments {
+                    name.push_str(&segment.ident.to_string());
+                }
+
+                Some(name)
             }
             _ => None
         }
@@ -65,7 +74,7 @@ impl<'a> MetaItem<'a> {
 
     pub fn description(&self) -> &'static str {
         match self {
-            MetaItem::Ident(..) => "identifier",
+            MetaItem::Path(..) => "path",
             MetaItem::Literal(syn::Lit::Str(..)) => "string literal",
             MetaItem::Literal(syn::Lit::ByteStr(..)) => "byte string literal",
             MetaItem::Literal(syn::Lit::Byte(..)) => "byte literal",
@@ -81,7 +90,7 @@ impl<'a> MetaItem<'a> {
 
     pub fn is_bare(&self) -> bool {
         match self {
-            MetaItem::Ident(..) | MetaItem::Literal(..) => true,
+            MetaItem::Path(..) | MetaItem::Literal(..) => true,
             MetaItem::KeyValue(..) | MetaItem::List(..) => false,
         }
     }
@@ -104,7 +113,7 @@ impl<'a> MetaItem<'a> {
 impl<'a> Spanned for MetaItem<'a> {
     fn span(&self) -> Span {
         match self {
-            MetaItem::Ident(i) => i.span(),
+            MetaItem::Path(path) => path.span(),
             MetaItem::Literal(l) => l.span(),
             MetaItem::KeyValue(i, l) => {
                 i.span().join(l.span()).unwrap_or(Span::call_site())

--- a/core/src/from_meta/meta_item.rs
+++ b/core/src/from_meta/meta_item.rs
@@ -3,6 +3,7 @@ use syn::{self, punctuated::Punctuated};
 use generator::Result;
 use spanned::Spanned;
 use proc_macro::Span;
+use quote::ToTokens;
 
 #[derive(Debug, Copy, Clone)]
 pub enum MetaItem<'a> {
@@ -57,16 +58,7 @@ impl<'a> MetaItem<'a> {
 
         match self {
             Path(path) | KeyValue(path, _) | List(MetaItemList { path, .. }) => {
-                let mut name = String::new();
-
-                if let Some(_colon2) = path.leading_colon {
-                    name.push_str("::");
-                }
-                for segment in &path.segments {
-                    name.push_str(&segment.ident.to_string());
-                }
-
-                Some(name)
+                Some(path.to_token_stream().to_string())
             }
             _ => None
         }

--- a/core/src/from_meta/meta_item.rs
+++ b/core/src/from_meta/meta_item.rs
@@ -46,7 +46,7 @@ impl<'a> From<&'a syn::NestedMeta> for MetaItem<'a> {
     fn from(nested: &syn::NestedMeta) -> MetaItem {
         match nested {
             syn::NestedMeta::Meta(meta) => MetaItem::from(meta),
-            syn::NestedMeta::Literal(lit) => MetaItem::Literal(lit),
+            syn::NestedMeta::Lit(lit) => MetaItem::Literal(lit),
         }
     }
 }

--- a/core/src/from_meta/mod.rs
+++ b/core/src/from_meta/mod.rs
@@ -62,7 +62,7 @@ pub trait FromMeta: Sized {
 impl FromMeta for isize {
     fn from_meta(meta: MetaItem) -> Result<Self> {
         if let Int(i) = meta.lit()? {
-            match i.base10_digits().parse::<isize>() {
+            match i.base10_parse::<isize>() {
                 Ok(value) => return Ok(value),
                 Err(parse_int_error) =>
                     return Err(meta.value_span().error("value is out of range for `isize`")),
@@ -76,7 +76,7 @@ impl FromMeta for isize {
 impl FromMeta for usize {
     fn from_meta(meta: MetaItem) -> Result<Self> {
         if let Int(i) = meta.lit()? {
-            match i.base10_digits().parse::<usize>() {
+            match i.base10_parse::<usize>() {
                 Ok(value) => return Ok(value),
                 Err(parse_int_error) =>
                     return Err(meta.value_span().error("value is out of range for `usize`")),

--- a/core/src/generator.rs
+++ b/core/src/generator.rs
@@ -182,7 +182,7 @@ impl DeriveGenerator {
     validator!(validate_generics: &syn::Generics, generics_validator);
     validator!(validate_fields: Fields, fields_validator);
 
-    pub fn function<F: 'static>(&mut self, f: F) -> &mut Self 
+    pub fn function<F: 'static>(&mut self, f: F) -> &mut Self
         where F: Fn(&DeriveGenerator, TokenStream2) -> TokenStream2
     {
         self.functions.push(Box::new(f));
@@ -361,7 +361,7 @@ impl DeriveGenerator {
                     use proc_macro::Span;
                     use proc_macro::Level::*;
 
-                    let id = &last.value().ident;
+                    let id = &last.ident;
                     let msg = match diag.level() {
                         Error => format!("error occurred while deriving `{}`", id),
                         Warning => format!("warning issued by `{}` derive", id),

--- a/examples/from_form_value/Cargo.toml
+++ b/examples/from_form_value/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote-next = "1.0.0-rc1"
+quote = "1.0"
 devise = { path = "../../lib" }
 
 # used by main.rs

--- a/examples/from_form_value/Cargo.toml
+++ b/examples/from_form_value/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote = "0.6"
+quote-next = "1.0.0-rc1"
 devise = { path = "../../lib" }
 
 # used by main.rs

--- a/examples/generics/Cargo.toml
+++ b/examples/generics/Cargo.toml
@@ -13,5 +13,5 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote-next = "1.0.0-rc1"
+quote = "1.0"
 devise = { path = "../../lib" }

--- a/examples/generics/Cargo.toml
+++ b/examples/generics/Cargo.toml
@@ -13,5 +13,5 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote = "0.6"
+quote-next = "1.0.0-rc1"
 devise = { path = "../../lib" }

--- a/examples/responder/Cargo.toml
+++ b/examples/responder/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote-next = "1.0.0-rc1"
+quote = "1.0"
 devise = { path = "../../lib" }
-proc-macro2-next = "1.0.0-rc1"
+proc-macro2 = "1.0"
 rocket_http = { git = "https://github.com/SergioBenitez/Rocket" }
 
 # used by main.rs

--- a/examples/responder/Cargo.toml
+++ b/examples/responder/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote = "0.6"
+quote-next = "1.0.0-rc1"
 devise = { path = "../../lib" }
-proc-macro2 = "*"
+proc-macro2-next = "1.0.0-rc1"
 rocket_http = { git = "https://github.com/SergioBenitez/Rocket" }
 
 # used by main.rs

--- a/examples/uri_display/Cargo.toml
+++ b/examples/uri_display/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote-next = "1.0.0-rc1"
+quote = "1.0"
 devise = { path = "../../lib" }
 
 # used by main.rs

--- a/examples/uri_display/Cargo.toml
+++ b/examples/uri_display/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-quote = "0.6"
+quote-next = "1.0.0-rc1"
 devise = { path = "../../lib" }
 
 # used by main.rs


### PR DESCRIPTION
I have updated the syn, quote and proc-macro2 dependencies to the stable 1.0.x versions.
For details you can look at the [official announcement](https://github.com/dtolnay/syn/releases/tag/1.0.0).

I am very unsure about the implementation and usage of `MetaItem::name(&self)`, so please take a special look at this function while reviewing.